### PR TITLE
Bugfix: Allow args to override default page number

### DIFF
--- a/src/querybuilder.js
+++ b/src/querybuilder.js
@@ -6,9 +6,9 @@ const Emitter = require('emitter20')
 const get = curryN(3, (type, page, args) => {
   return request({
     uri: `${config.endpoint}/${type}`,
-    qs: merge(args, {
+    qs: merge({
       page
-    }),
+    }, args),
     json: true
   }).then(prop(type))
 })


### PR DESCRIPTION
By default, calling `where()` sets the page property to 1. If the user tries to override the value for page by passing `{ page: 2 }` for args, the value for page will be overwritten when the call to `merge()` applies the hard-coded 1.

Reproducing the error is simple, if you try to set the page when calling `where()`

```js
pokemon.card.where({ page: 1, pageSize: 10 })
.then(cards => {
    console.log(cards.length)  // 10
    console.log(cards[0].name) // Vespiquen
});
```

```js
pokemon.card.where({ page: 2, pageSize: 10 })
.then(cards => {
    console.log(cards.length)  // 10
    console.log(cards[0].name) // Vespiquen
});
```

By switching the order things are merged in, the page size is allowed to take effect!

```js
pokemon.card.where({ page: 2, pageSize: 10 })
.then(cards => {
    console.log(cards.length)  // 10
    console.log(cards[0].name) // Misdreavus
});
```

From: https://ramdajs.com/docs/#merge
> If a key exists in both objects, the value from the second object will be used.